### PR TITLE
Ignore large data files when making releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/GSHHS export-ignore
+/WDBII export-ignore
+/to_add export-ignore


### PR DESCRIPTION
When we make a release, GitHub will create two tarballs for the whole
repository. We have many data files in the repository, so the two
tarballs will be pretty large (~500 MB).

Those github-generated tarballs are almost useless to us.
In `.gitattributes` we can let github ignore the GSHHHG, WDBII and
to_add directories when making tarballs.